### PR TITLE
Remove deprecated proxy URL from mirrors.js

### DIFF
--- a/static/js/mirrors.js
+++ b/static/js/mirrors.js
@@ -31,7 +31,6 @@ window.mirrors = [
     "https://gh-proxy.com",
     "https://gh.b52m.cn",
     "https://gh.bugdey.us.kg",
-    "https://gh.wsmdn.dpdns.org",
     "https://github.lxxz.xyz",
     "http://gh.927223.xyz",
     "https://ghp.qi9420.xyz",


### PR DESCRIPTION
最近我的服务像是被滥用了，每天都有190k+的请求，我实在是负担不起，现在服务已经关了，所以我删一下我的加速地址，实在对不起